### PR TITLE
Add name to allowable params and update database

### DIFF
--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -46,6 +46,6 @@ class FormSubmissionsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def form_submission_params
-      params.require(:form_submission).permit(:objectid, :resolved, :email, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src)
+      params.require(:form_submission).permit(:objectid, :resolved, :email, :name, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src)
     end
 end

--- a/db/migrate/20201223202237_add_name_to_submission.rb
+++ b/db/migrate/20201223202237_add_name_to_submission.rb
@@ -1,0 +1,5 @@
+class AddNameToSubmission < ActiveRecord::Migration[6.0]
+  def change
+    add_column :form_submissions, :name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_12_23_202237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "view_src", limit: 2
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "name"
     t.index ["objectid"], name: "r19_sde_rowid_uk", unique: true
   end
+
 end

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     objectid { 0 }
     resolved { 0 }
     email { 'devnull@mapc.org' }
+    name { 'Test Name' }
     zo_name { 'Test Zone' }
     zo_usety { 0 }
     zo_usede { 'Filler text' }


### PR DESCRIPTION
Resolves #1 

Includes migration to add a string "name" to the database, plus allow the "name" parameter in POST requests.

Example cURL request for testing:

```
curl -X "POST" "localhost:3000/form_submissions" \
    -H 'Content-Type: application/json; charset=utf-8' \
    -d $'{
"form_submission": {
  "objectid": 1,
  "email": "devnull@mapc.org",
  "name": "Baby Yoda"
}
}'
```