### PR TITLE
Att/2 identifying columns

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,5 +27,6 @@ group :development do
   gem 'guard'
   gem 'guard-livereload'
   gem 'guard-rspec'
+  gem 'rack-cors'
   gem 'terminal-notifier-guard'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     puma (4.3.7)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-cors (1.1.1)
+      rack (>= 2.0.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.4)
@@ -251,6 +253,7 @@ DEPENDENCIES
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
   puma (~> 4.1)
+  rack-cors
   rails (~> 6.0.3, >= 6.0.3.4)
   rspec-rails
   spring

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -46,6 +46,6 @@ class FormSubmissionsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def form_submission_params
-      params.require(:form_submission).permit(:objectid, :resolved, :email, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src)
+      params.require(:form_submission).permit(:objectid, :resolved, :email, :name, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src)
     end
 end

--- a/app/controllers/form_submissions_controller.rb
+++ b/app/controllers/form_submissions_controller.rb
@@ -46,6 +46,6 @@ class FormSubmissionsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def form_submission_params
-      params.require(:form_submission).permit(:objectid, :resolved, :email, :name, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src)
+      params.require(:form_submission).permit(:objectid, :resolved, :email, :name, :zo_name, :zo_usety, :zo_usede, :multifam, :minlotsize, :pctlotcov, :lapdu, :maxflrs, :maxheight, :maxdu, :dupac, :far, :gen_coms, :view_src, :zone_objectid, :zone_rowid, :municipality)
     end
 end

--- a/db/migrate/20201223202237_add_name_to_submission.rb
+++ b/db/migrate/20201223202237_add_name_to_submission.rb
@@ -1,0 +1,5 @@
+class AddNameToSubmission < ActiveRecord::Migration[6.0]
+  def change
+    add_column :form_submissions, :name, :string
+  end
+end

--- a/db/migrate/20201224164848_add_muni_and_ids_to_submission.rb
+++ b/db/migrate/20201224164848_add_muni_and_ids_to_submission.rb
@@ -1,0 +1,7 @@
+class AddMuniAndIdsToSubmission < ActiveRecord::Migration[6.0]
+  def change
+    add_column :form_submissions, :municipality, :string
+    add_column :form_submissions, :zone_objectid, :integer
+    add_column :form_submissions, :zone_rowid, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 2020_12_23_202237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,8 @@ ActiveRecord::Schema.define(version: 0) do
     t.integer "view_src", limit: 2
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "name"
     t.index ["objectid"], name: "r19_sde_rowid_uk", unique: true
   end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_23_202237) do
+ActiveRecord::Schema.define(version: 2020_12_24_164848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,9 @@ ActiveRecord::Schema.define(version: 2020_12_23_202237) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "name"
+    t.string "municipality"
+    t.integer "zone_objectid"
+    t.integer "zone_rowid"
     t.index ["objectid"], name: "r19_sde_rowid_uk", unique: true
   end
 

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -18,5 +18,8 @@ FactoryBot.define do
     far { 0.59 }
     gen_coms { 'The endzone!' }
     view_src { 0 }
+    municipality { 'Acton' }
+    zone_objectid { '1234' }
+    zone_rowid { null }
   end
 end

--- a/spec/factories/form_submissions.rb
+++ b/spec/factories/form_submissions.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     objectid { 0 }
     resolved { 0 }
     email { 'devnull@mapc.org' }
+    name { 'Test Name' }
     zo_name { 'Test Zone' }
     zo_usety { 0 }
     zo_usede { 'Filler text' }


### PR DESCRIPTION
Resolves #3 (I goofed on branch naming)

I added both `zone_objectid` and `zone_rowid` to the Factory spec, but since only one should ever be filled out (objectid for submissions from the map view and rowid for submissions from the table view) I set the latter to null. I know you don't need to include unneeded fields in a Factory spec, but wasn't sure if it's better practice to include it as null (which we would expect) or exclude it from the factory altogether.